### PR TITLE
Support nested folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Overview
 
-The **Snippets Manager Plugin** for Obsidian allows you to manage and quickly insert text snippets stored in a markdown file. This plugin enhances your workflow by enabling fuzzy search for snippets, allowing you to copy them to your clipboard or directly paste them at the cursor position in your active note. Now, with Alfred integration and Awesome ChatGPT Prompts support, it's even more powerful.
+The **Snippets Manager Plugin** for Obsidian allows you to manage and quickly insert text snippets stored in a markdown file (or folder of markdown files, including subfolders). This plugin enhances your workflow by enabling fuzzy search for snippets, allowing you to copy them to your clipboard or directly paste them at the cursor position in your active note. Now, with Alfred integration and Awesome ChatGPT Prompts support, it's even more powerful.
 
 ![Obsidian Snippet Manager](https://github.com/user-attachments/assets/95f10833-faff-4313-8263-89dae134c60b)
 
@@ -48,6 +48,7 @@ On my desktop, Snippet Manager is my go-to tool for copying ChatGPT prompts. Iâ€
 ## Features
 
 - **Snippet Management:** Store snippets in a markdown file with headings as keys (whether personal details like email signature, passport number, code snippets or anything).
+- **Folder Support:** The plugin supports snippets stored in a folder of markdown files, including subfolders. Either select the single markdown file in Settings for the plugin, or the folder containing the snippets.
 - **Code Snippets**: The plugin supports code snippets stored in markdown code blocks. When retrieving a code snippet, the plugin automatically strips the backticks, providing you with just the clean code.
 - **Fuzzy Search:** Quickly search through snippets using a fuzzy search interface.
 - **Clipboard Copying:** Copy selected snippets to your clipboard.
@@ -100,7 +101,7 @@ Best regards,
 ### Hello World
 ```js
 helloworld() {
-console.log("Hello World!!!"); 
+console.log("Hello World!!!");
 }
 ```
 ````

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ On my desktop, Snippet Manager is my go-to tool for copying ChatGPT prompts. Iâ€
 ## Features
 
 - **Snippet Management:** Store snippets in a markdown file with headings as keys (whether personal details like email signature, passport number, code snippets or anything).
-- **Folder Support:** The plugin supports snippets stored in a folder of markdown files, including subfolders. Either select the single markdown file in Settings for the plugin, or the folder containing the snippets.
+- **Folder Support:** The plugin supports snippets stored in a folder of markdown files, including subfolders. Either select the single markdown file in Settings for the plugin, or the folder containing the markdown files with snippets.
 - **Code Snippets**: The plugin supports code snippets stored in markdown code blocks. When retrieving a code snippet, the plugin automatically strips the backticks, providing you with just the clean code.
 - **Fuzzy Search:** Quickly search through snippets using a fuzzy search interface.
 - **Clipboard Copying:** Copy selected snippets to your clipboard.

--- a/src/SnippetManagerPlugin.ts
+++ b/src/SnippetManagerPlugin.ts
@@ -1,272 +1,248 @@
-import { Plugin, Notice, TFile, TFolder, CachedMetadata } from "obsidian";
-import SnippetSuggestModal from "./SnippetSuggestModal";
-import SnippetManagerSettingTab from "./SnippetManagerSettingTab";
-import ChatGPTPromptManager from "./ChatGPTPromptManager";
+import { Plugin, Notice, TFile, TFolder, CachedMetadata } from 'obsidian';
+import SnippetSuggestModal from './SnippetSuggestModal';
+import SnippetManagerSettingTab from './SnippetManagerSettingTab';
+import ChatGPTPromptManager from './ChatGPTPromptManager';
 
 export interface SnippetManagerSettings {
-	snippetPath: string; // Can be either a file or a directory
-	alfredSupport: boolean;
+    snippetPath: string; // Can be either a file or a directory
+    alfredSupport: boolean; 
 }
 
 const DEFAULT_SETTINGS: SnippetManagerSettings = {
-	snippetPath: "Snippets.md", // Default to single file for backward compatibility
-	alfredSupport: false,
+    snippetPath: "Snippets.md", // Default to single file for backward compatibility
+    alfredSupport: false,
 };
 
 export default class SnippetManagerPlugin extends Plugin {
-	settings: SnippetManagerSettings;
-	snippets: Record<string, string> = {};
-	lastModifiedTimes: Record<string, number> = {}; // Track modified times for multiple files
-	isSnippetsReloaded = false;
+    settings: SnippetManagerSettings;
+    snippets: Record<string, string> = {};
+    lastModifiedTimes: Record<string, number> = {}; // Track modified times for multiple files
+    isSnippetsReloaded = false;
 
-	async onload() {
-		// Load settings
-		await this.loadSettings();
+    async onload() {
+        // Load settings
+        await this.loadSettings();
 
-		// Add settings tab
-		this.addSettingTab(new SnippetManagerSettingTab(this.app, this));
+        // Add settings tab
+        this.addSettingTab(new SnippetManagerSettingTab(this.app, this));
 
-		// Add command to trigger the fuzzy suggester
-		this.addCommand({
-			id: "open-snippet-search",
-			name: "Search Snippets",
-			editorCallback: (editor, view) => {
-				new SnippetSuggestModal(this.app, this, editor).open();
-			},
-		});
+        // Add command to trigger the fuzzy suggester
+        this.addCommand({
+            id: 'open-snippet-search',
+            name: 'Search Snippets',
+            editorCallback: (editor, view) => {
+                new SnippetSuggestModal(this.app, this, editor).open();
+            }
+        });
 
-		// Add command to sync Awesome ChatGPT prompts
-		this.addCommand({
-			id: "sync-chatgpt-prompts",
-			name: "Sync Awesome ChatGPT Prompts",
-			callback: async () => {
-				const snippetPath = this.settings.snippetPath; // You can make this dynamic based on user settings
-				const fileOrFolder =
-					this.app.vault.getAbstractFileByPath(snippetPath);
-				if (!fileOrFolder) {
-					new Notice(`Snippet path not found: ${snippetPath}`);
-					return;
-				}
-				if (fileOrFolder instanceof TFolder) {
-					const promptManager = new ChatGPTPromptManager(this);
-					// Define your snippets folder path, e.g., 'Snippets/'
-					await promptManager.fetchLatestChatGPTPrompts(snippetPath);
-					this.loadSnippets();
-				} else {
-					new Notice(`Error: Snippet path should be an folder.`);
-				}
-			},
-		});
+        // Add command to sync Awesome ChatGPT prompts
+        this.addCommand({
+            id: 'sync-chatgpt-prompts',
+            name: 'Sync Awesome ChatGPT Prompts',
+            callback: async () => {
+                const snippetPath = this.settings.snippetPath; // You can make this dynamic based on user settings
+                const fileOrFolder = this.app.vault.getAbstractFileByPath(snippetPath);
+                if (!fileOrFolder) {
+                    new Notice(`Snippet path not found: ${snippetPath}`);
+                    return;
+                }
+                if (fileOrFolder instanceof TFolder) {
+                    const promptManager = new ChatGPTPromptManager(this);
+                    // Define your snippets folder path, e.g., 'Snippets/'
+                    await promptManager.fetchLatestChatGPTPrompts(snippetPath);
+                    this.loadSnippets();
+                }
+                else {
+                    new Notice(`Error: Snippet path should be an folder.`);
+                }
 
-		// Wait for the layout to be ready before loading snippets
-		this.app.workspace.onLayoutReady(() => {
-			this.loadSnippets();
-		});
-	}
+            }
+        });
 
-	clearSnippets() {
-		this.snippets = {};
-		this.lastModifiedTimes = {};
-	}
+        // Wait for the layout to be ready before loading snippets
+        this.app.workspace.onLayoutReady(() => {
+            this.loadSnippets();
+        });
+    }
 
-	async loadSnippets() {
-		this.isSnippetsReloaded = false;
-		const snippetPath = this.settings.snippetPath;
-		const fileOrFolder = this.app.vault.getAbstractFileByPath(snippetPath);
+    clearSnippets() {
+        this.snippets = {};
+        this.lastModifiedTimes = {};
+    }
 
-		if (!fileOrFolder) {
-			new Notice(`Snippet path not found: ${snippetPath}`);
-			return;
-		}
+    async loadSnippets() {
+        this.isSnippetsReloaded = false;
+        const snippetPath = this.settings.snippetPath;
+        const fileOrFolder = this.app.vault.getAbstractFileByPath(snippetPath);
 
-		if (fileOrFolder instanceof TFolder) {
-			const markdownFiles = this.getAllMarkdownFiles(fileOrFolder);
+        if (!fileOrFolder) {
+            new Notice(`Snippet path not found: ${snippetPath}`);
+            return;
+        }
 
-			const addFilePrefix = markdownFiles.length > 1;
+        if (fileOrFolder instanceof TFolder) {
+            const markdownFiles = this.getAllMarkdownFiles(fileOrFolder);
+            const addFilePrefix = markdownFiles.length > 1;
 
-			for (let file of markdownFiles) {
-				await this.loadSnippetsFromFile(file, addFilePrefix);
-			}
-		} else if (
-			fileOrFolder instanceof TFile &&
-			fileOrFolder.extension === "md"
-		) {
-			// Handle single file
-			await this.loadSnippetsFromFile(fileOrFolder, false);
-		} else {
-			new Notice(`Invalid snippet path: ${snippetPath}`);
-		}
+            // Handle directory: load snippets from all markdown files in the folder
+            for (let file of markdownFiles) {
+                if (file instanceof TFile) {
+                    await this.loadSnippetsFromFile(file, addFilePrefix);
+                }
+            }
+        } else if (fileOrFolder instanceof TFile && fileOrFolder.extension === 'md') {
+            // Handle single file
+            await this.loadSnippetsFromFile(fileOrFolder, false);
+        } else {
+            new Notice(`Invalid snippet path: ${snippetPath}`);
+        }
 
-		if (this.isSnippetsReloaded) {
-			await this.saveSnippetsAsAlfredJson();
-			this.isSnippetsReloaded = false;
-		}
-	}
+        if(this.isSnippetsReloaded) {
+            await this.saveSnippetsAsAlfredJson();
+            this.isSnippetsReloaded = false;
+        }
+    }
 
-	async loadSnippetsFromFile(file: TFile, addFilePrefix: boolean) {
-		const filePath = file.path;
-		const fileStat = await this.app.vault.adapter.stat(filePath);
-		const modifiedTime = fileStat?.mtime;
+    async loadSnippetsFromFile(file: TFile, addFilePrefix: boolean) {
+        const filePath = file.path;
+        const fileStat = await this.app.vault.adapter.stat(filePath);
+        const modifiedTime = fileStat?.mtime;
 
-		// Check if the file has been modified since the last load
-		if (
-			modifiedTime &&
-			(!this.lastModifiedTimes[filePath] ||
-				modifiedTime > this.lastModifiedTimes[filePath])
-		) {
-			const content = await this.app.vault.cachedRead(file);
-			const contentCache = this.app.metadataCache.getFileCache(file);
+        // Check if the file has been modified since the last load
+        if (modifiedTime && (!this.lastModifiedTimes[filePath] || modifiedTime > this.lastModifiedTimes[filePath])) {
+            const content = await this.app.vault.cachedRead(file);
+            const contentCache = this.app.metadataCache.getFileCache(file);
 
-			// Merge snippets from this file into the global snippets
-			const filePrefix = addFilePrefix
-				? this.getRelativePath(file, this.settings.snippetPath)
-				: null;
-			Object.assign(
-				this.snippets,
-				this.getSnippets(content, contentCache, filePrefix)
-			);
+            // Merge snippets from this file into the global snippets
+            const filePrefix = addFilePrefix ? this.getRelativePath(file, this.settings.snippetPath) : null;
+            Object.assign(this.snippets, this.getSnippets(content, contentCache, filePrefix));
 
-			this.lastModifiedTimes[filePath] = modifiedTime;
-			// new Notice(`Snippets reloaded from: ${filePath}`);
-			this.isSnippetsReloaded = true;
-		}
-	}
+            this.lastModifiedTimes[filePath] = modifiedTime;
+            // new Notice(`Snippets reloaded from: ${filePath}`);
+            this.isSnippetsReloaded = true;
+        }
+    }
 
-	getSnippets(
-		content: string,
-		contentCache: CachedMetadata | null,
-		filePrefix: string | null
-	): Record<string, string> {
-		const snippets: Record<string, string> = {};
+    getSnippets(content: string, contentCache: CachedMetadata | null, filePrefix: string | null): Record<string, string> {
+        const snippets: Record<string, string> = {};
 
-		if (!contentCache?.headings) {
-			return snippets; // No headings found, return empty snippets
-		}
+        if (!contentCache?.headings) {
+            return snippets; // No headings found, return empty snippets
+        }
 
-		const headings = contentCache.headings;
-		const level = headings[0].level;
+        const headings = contentCache.headings;
+        const level = headings[0].level;
 
-		// Ensure all headings are at the same level
-		for (let i = 0; i < headings.length; i++) {
-			if (headings[i].level !== level) {
-				new Notice(
-					`Please follow the same heading level throughout the file`
-				);
-				return snippets;
-			}
-		}
+        // Ensure all headings are at the same level
+        for (let i = 0; i < headings.length; i++) {
+            if (headings[i].level !== level) {
+                new Notice(`Please follow the same heading level throughout the file`);
+                return snippets;
+            }
+        }
 
-		// Iterate over headings and capture content
-		for (let i = 0; i < headings.length; i++) {
-			const currentHeading = headings[i];
-			let sectionContent = "";
+        // Iterate over headings and capture content
+        for (let i = 0; i < headings.length; i++) {
+            const currentHeading = headings[i];
+            let sectionContent = '';
 
-			if (i + 1 === headings.length) {
-				sectionContent = content.slice(
-					currentHeading.position.end.offset + 1
-				);
-			} else {
-				const nextHeading = headings[i + 1];
-				sectionContent = content.slice(
-					currentHeading.position.end.offset + 1,
-					nextHeading.position.start.offset - 1
-				);
-			}
+            if (i + 1 === headings.length) {
+                sectionContent = content.slice(currentHeading.position.end.offset + 1);
+            } else {
+                const nextHeading = headings[i + 1];
+                sectionContent = content.slice(
+                    currentHeading.position.end.offset + 1,
+                    nextHeading.position.start.offset - 1
+                );
+            }
 
-			// Remove code block formatting
-			sectionContent =
-				this.stripCodeBlockFormatting(sectionContent).trim();
+            // Remove code block formatting
+            sectionContent = this.stripCodeBlockFormatting(sectionContent).trim();
 
-			// Prefix with file name if needed
-			const snippetKey =
-				filePrefix && filePrefix !== ""
-					? `${filePrefix}: ${currentHeading.heading}`
-					: currentHeading.heading;
+            // Prefix with file name if needed
+            const snippetKey = filePrefix && filePrefix !== '' ? `${filePrefix}: ${currentHeading.heading}` : currentHeading.heading;
 
-			// Store the section content with the heading as the key
-			snippets[snippetKey] = sectionContent;
-		}
+            // Store the section content with the heading as the key
+            snippets[snippetKey] = sectionContent;
+        }
 
-		return snippets;
-	}
+        return snippets;
+    }
 
-	stripCodeBlockFormatting(content: string): string {
-		return content.replace(/```[\s\S]*?```/g, (match) => {
-			// Remove the starting and ending backticks, and any language identifier
-			return match.replace(/```(\w+)?\n?/, "").replace(/\n?```$/, "");
-		});
-	}
+    stripCodeBlockFormatting(content: string): string {
+        return content.replace(/```[\s\S]*?```/g, (match) => {
+            // Remove the starting and ending backticks, and any language identifier
+            return match.replace(/```(\w+)?\n?/, '').replace(/\n?```$/, '');
+        });
+    }
 
-	// Save the snippets as a JSON file in Alfred's snippet format
-	async saveSnippetsAsAlfredJson() {
-		if (!this.settings.alfredSupport) {
-			return;
-		}
 
-		let idCounter = 1; // Initialize a counter for sequential UIDs
-		const alfredSnippets = Object.keys(this.snippets).map((key) => {
-			return {
-				uid: idCounter++, // Unique ID for each snippet
-				title: key, // Snippet title
-				subtitle: this.snippets[key], // Snippet content
-				arg: this.snippets[key], // Snippet content
-				key: key, // Set the key as the trigger keyword
-			};
-		});
+    // Save the snippets as a JSON file in Alfred's snippet format
+    async saveSnippetsAsAlfredJson() {
+        if(!this.settings.alfredSupport) {
+            return;
+        }
 
-		const jsonContent = JSON.stringify({ items: alfredSnippets }, null, 2); // Format the JSON
-		const jsonFilePath = `${this.manifest.dir}/alfred-snippets.json`; // Path to store the JSON file in the plugin's directory
+        let idCounter = 1; // Initialize a counter for sequential UIDs
+        const alfredSnippets = Object.keys(this.snippets).map((key) => {
+            return {
+                    "uid": idCounter++, // Unique ID for each snippet
+                    "title": key, // Snippet title
+                    "subtitle": this.snippets[key], // Snippet content
+                    "arg": this.snippets[key], // Snippet content
+                    "key": key // Set the key as the trigger keyword
+            };
+        });
 
-		try {
-			await this.app.vault.adapter.write(jsonFilePath, jsonContent); // Save the JSON file
-			// new Notice(`Snippets saved as Alfred JSON in: ${jsonFilePath}`);
-		} catch (error) {
-			console.error("Error saving snippets as Alfred JSON:", error);
-			new Notice("Failed to save snippets as Alfred JSON");
-		}
-	}
+        const jsonContent = JSON.stringify({ items: alfredSnippets }, null, 2); // Format the JSON
+        const jsonFilePath = `${this.manifest.dir}/alfred-snippets.json`; // Path to store the JSON file in the plugin's directory
 
-	async loadSettings() {
-		const data = await this.loadData();
+        try {
+            await this.app.vault.adapter.write(jsonFilePath, jsonContent); // Save the JSON file
+            // new Notice(`Snippets saved as Alfred JSON in: ${jsonFilePath}`);
+        } catch (error) {
+            console.error('Error saving snippets as Alfred JSON:', error);
+            new Notice('Failed to save snippets as Alfred JSON');
+        }
+    }
 
-		// Migrate old setting (snippetFilePath) to the new one (snippetPath) if it exists
-		if (data?.snippetFilePath && !data.snippetPath) {
-			data.snippetPath = data.snippetFilePath; // Copy old setting to the new key
-			delete data.snippetFilePath; // Optionally remove the old key if no longer needed
-		}
+    async loadSettings() {
+        const data = await this.loadData();
 
-		// Merge default settings with loaded/migrated settings
-		this.settings = Object.assign({}, DEFAULT_SETTINGS, data);
+        // Migrate old setting (snippetFilePath) to the new one (snippetPath) if it exists
+        if (data?.snippetFilePath && !data.snippetPath) {
+            data.snippetPath = data.snippetFilePath; // Copy old setting to the new key
+            delete data.snippetFilePath; // Optionally remove the old key if no longer needed
+        }
 
-		// Save settings after migration to ensure future consistency
-		await this.saveSettings();
-	}
+        // Merge default settings with loaded/migrated settings
+        this.settings = Object.assign({}, DEFAULT_SETTINGS, data);
 
-	async saveSettings() {
-		await this.saveData(this.settings);
-	}
+        // Save settings after migration to ensure future consistency
+        await this.saveSettings();
+    }
 
-	getRelativePath(file: TFile, rootPath: string): string {
-		let relativePath = file.path.slice(rootPath.length);
-		if (relativePath.startsWith("/")) {
-			relativePath = relativePath.slice(1);
-		}
-		return relativePath.replace(/\.md$/, "");
-	}
+    async saveSettings() {
+        await this.saveData(this.settings);
+    }
 
-	getAllMarkdownFiles(folder: TFolder): TFile[] {
-		let markdownFiles: TFile[] = [];
+    getRelativePath(file: TFile, rootPath: string): string {
+        let relativePath = file.path.slice(rootPath.length);
+        if (relativePath.startsWith('/')) {
+            relativePath = relativePath.slice(1);
+        }
+        return relativePath.replace(/\.md$/, '');
+    }
 
-		folder.children.forEach((child) => {
-			if (child instanceof TFile && child.extension === "md") {
-				markdownFiles.push(child);
-			} else if (child instanceof TFolder) {
-				markdownFiles = markdownFiles.concat(
-					this.getAllMarkdownFiles(child)
-				);
-			}
-		});
-
-		return markdownFiles;
-	}
+    getAllMarkdownFiles(folder: TFolder): TFile[] {
+        let markdownFiles: TFile[] = [];
+        folder.children.forEach((child) => {
+            if (child instanceof TFile && child.extension === "md") {
+                markdownFiles.push(child);
+            } else if (child instanceof TFolder) {
+                markdownFiles = markdownFiles.concat(this.getAllMarkdownFiles(child));
+            }
+        });
+        return markdownFiles;
+    }
 }

--- a/src/SnippetManagerPlugin.ts
+++ b/src/SnippetManagerPlugin.ts
@@ -1,231 +1,272 @@
-import { Plugin, Notice, TFile, TFolder, CachedMetadata } from 'obsidian';
-import SnippetSuggestModal from './SnippetSuggestModal';
-import SnippetManagerSettingTab from './SnippetManagerSettingTab';
-import ChatGPTPromptManager from './ChatGPTPromptManager';
+import { Plugin, Notice, TFile, TFolder, CachedMetadata } from "obsidian";
+import SnippetSuggestModal from "./SnippetSuggestModal";
+import SnippetManagerSettingTab from "./SnippetManagerSettingTab";
+import ChatGPTPromptManager from "./ChatGPTPromptManager";
 
 export interface SnippetManagerSettings {
-    snippetPath: string; // Can be either a file or a directory
-    alfredSupport: boolean; 
+	snippetPath: string; // Can be either a file or a directory
+	alfredSupport: boolean;
 }
 
 const DEFAULT_SETTINGS: SnippetManagerSettings = {
-    snippetPath: "Snippets.md", // Default to single file for backward compatibility
-    alfredSupport: false,
+	snippetPath: "Snippets.md", // Default to single file for backward compatibility
+	alfredSupport: false,
 };
 
 export default class SnippetManagerPlugin extends Plugin {
-    settings: SnippetManagerSettings;
-    snippets: Record<string, string> = {};
-    lastModifiedTimes: Record<string, number> = {}; // Track modified times for multiple files
-    isSnippetsReloaded = false;
+	settings: SnippetManagerSettings;
+	snippets: Record<string, string> = {};
+	lastModifiedTimes: Record<string, number> = {}; // Track modified times for multiple files
+	isSnippetsReloaded = false;
 
-    async onload() {
-        // Load settings
-        await this.loadSettings();
+	async onload() {
+		// Load settings
+		await this.loadSettings();
 
-        // Add settings tab
-        this.addSettingTab(new SnippetManagerSettingTab(this.app, this));
+		// Add settings tab
+		this.addSettingTab(new SnippetManagerSettingTab(this.app, this));
 
-        // Add command to trigger the fuzzy suggester
-        this.addCommand({
-            id: 'open-snippet-search',
-            name: 'Search Snippets',
-            editorCallback: (editor, view) => {
-                new SnippetSuggestModal(this.app, this, editor).open();
-            }
-        });
+		// Add command to trigger the fuzzy suggester
+		this.addCommand({
+			id: "open-snippet-search",
+			name: "Search Snippets",
+			editorCallback: (editor, view) => {
+				new SnippetSuggestModal(this.app, this, editor).open();
+			},
+		});
 
-        // Add command to sync Awesome ChatGPT prompts
-        this.addCommand({
-            id: 'sync-chatgpt-prompts',
-            name: 'Sync Awesome ChatGPT Prompts',
-            callback: async () => {
-                const snippetPath = this.settings.snippetPath; // You can make this dynamic based on user settings
-                const fileOrFolder = this.app.vault.getAbstractFileByPath(snippetPath);
-                if (!fileOrFolder) {
-                    new Notice(`Snippet path not found: ${snippetPath}`);
-                    return;
-                }
-                if (fileOrFolder instanceof TFolder) {
-                    const promptManager = new ChatGPTPromptManager(this);
-                    // Define your snippets folder path, e.g., 'Snippets/'
-                    await promptManager.fetchLatestChatGPTPrompts(snippetPath);
-                    this.loadSnippets();
-                }
-                else {
-                    new Notice(`Error: Snippet path should be an folder.`);
-                }
+		// Add command to sync Awesome ChatGPT prompts
+		this.addCommand({
+			id: "sync-chatgpt-prompts",
+			name: "Sync Awesome ChatGPT Prompts",
+			callback: async () => {
+				const snippetPath = this.settings.snippetPath; // You can make this dynamic based on user settings
+				const fileOrFolder =
+					this.app.vault.getAbstractFileByPath(snippetPath);
+				if (!fileOrFolder) {
+					new Notice(`Snippet path not found: ${snippetPath}`);
+					return;
+				}
+				if (fileOrFolder instanceof TFolder) {
+					const promptManager = new ChatGPTPromptManager(this);
+					// Define your snippets folder path, e.g., 'Snippets/'
+					await promptManager.fetchLatestChatGPTPrompts(snippetPath);
+					this.loadSnippets();
+				} else {
+					new Notice(`Error: Snippet path should be an folder.`);
+				}
+			},
+		});
 
-            }
-        });
+		// Wait for the layout to be ready before loading snippets
+		this.app.workspace.onLayoutReady(() => {
+			this.loadSnippets();
+		});
+	}
 
-        // Wait for the layout to be ready before loading snippets
-        this.app.workspace.onLayoutReady(() => {
-            this.loadSnippets();
-        });
-    }
+	clearSnippets() {
+		this.snippets = {};
+		this.lastModifiedTimes = {};
+	}
 
-    clearSnippets() {
-        this.snippets = {};
-        this.lastModifiedTimes = {};
-    }
+	async loadSnippets() {
+		this.isSnippetsReloaded = false;
+		const snippetPath = this.settings.snippetPath;
+		const fileOrFolder = this.app.vault.getAbstractFileByPath(snippetPath);
 
-    async loadSnippets() {
-        this.isSnippetsReloaded = false;
-        const snippetPath = this.settings.snippetPath;
-        const fileOrFolder = this.app.vault.getAbstractFileByPath(snippetPath);
+		if (!fileOrFolder) {
+			new Notice(`Snippet path not found: ${snippetPath}`);
+			return;
+		}
 
-        if (!fileOrFolder) {
-            new Notice(`Snippet path not found: ${snippetPath}`);
-            return;
-        }
+		if (fileOrFolder instanceof TFolder) {
+			const markdownFiles = getAllMarkdownFiles(fileOrFolder);
 
-        if (fileOrFolder instanceof TFolder) {
-            // Check if the folder contains more than one file
-            const markdownFiles = fileOrFolder.children.filter(
-                (file) => file instanceof TFile && file.extension === 'md'
-            );
+			const addFilePrefix = markdownFiles.length > 1;
 
-            const addFilePrefix = markdownFiles.length > 1;
+			for (let file of markdownFiles) {
+				await this.loadSnippetsFromFile(file, addFilePrefix);
+			}
+		} else if (
+			fileOrFolder instanceof TFile &&
+			fileOrFolder.extension === "md"
+		) {
+			// Handle single file
+			await this.loadSnippetsFromFile(fileOrFolder, false);
+		} else {
+			new Notice(`Invalid snippet path: ${snippetPath}`);
+		}
 
-            // Handle directory: load snippets from all markdown files in the folder
-            for (let file of markdownFiles) {
-                if (file instanceof TFile) {
-                    await this.loadSnippetsFromFile(file, addFilePrefix);
-                }
-            }
-        } else if (fileOrFolder instanceof TFile && fileOrFolder.extension === 'md') {
-            // Handle single file
-            await this.loadSnippetsFromFile(fileOrFolder, false);
-        } else {
-            new Notice(`Invalid snippet path: ${snippetPath}`);
-        }
+		if (this.isSnippetsReloaded) {
+			await this.saveSnippetsAsAlfredJson();
+			this.isSnippetsReloaded = false;
+		}
+	}
 
-        if(this.isSnippetsReloaded) {
-            await this.saveSnippetsAsAlfredJson();
-            this.isSnippetsReloaded = false;
-        }
-    }
+	async loadSnippetsFromFile(file: TFile, addFilePrefix: boolean) {
+		const filePath = file.path;
+		const fileStat = await this.app.vault.adapter.stat(filePath);
+		const modifiedTime = fileStat?.mtime;
 
-    async loadSnippetsFromFile(file: TFile, addFilePrefix: boolean) {
-        const filePath = file.path;
-        const fileStat = await this.app.vault.adapter.stat(filePath);
-        const modifiedTime = fileStat?.mtime;
+		// Check if the file has been modified since the last load
+		if (
+			modifiedTime &&
+			(!this.lastModifiedTimes[filePath] ||
+				modifiedTime > this.lastModifiedTimes[filePath])
+		) {
+			const content = await this.app.vault.cachedRead(file);
+			const contentCache = this.app.metadataCache.getFileCache(file);
 
-        // Check if the file has been modified since the last load
-        if (modifiedTime && (!this.lastModifiedTimes[filePath] || modifiedTime > this.lastModifiedTimes[filePath])) {
-            const content = await this.app.vault.cachedRead(file);
-            const contentCache = this.app.metadataCache.getFileCache(file);
+			// Merge snippets from this file into the global snippets
+			const filePrefix = addFilePrefix ? getRelativePath(file, this.settings.snippetPath) : null;
+			Object.assign(
+				this.snippets,
+				this.getSnippets(
+					content,
+					contentCache,
+					filePrefix
+				)
+			);
 
-            // Merge snippets from this file into the global snippets
-            Object.assign(this.snippets, this.getSnippets(content, contentCache, addFilePrefix ? file.basename : null));
+			this.lastModifiedTimes[filePath] = modifiedTime;
+			// new Notice(`Snippets reloaded from: ${filePath}`);
+			this.isSnippetsReloaded = true;
+		}
+	}
 
-            this.lastModifiedTimes[filePath] = modifiedTime;
-            // new Notice(`Snippets reloaded from: ${filePath}`);
-            this.isSnippetsReloaded = true;
-        }
-    }
+	getSnippets(
+		content: string,
+		contentCache: CachedMetadata | null,
+		filePrefix: string | null
+	): Record<string, string> {
+		const snippets: Record<string, string> = {};
 
-    getSnippets(content: string, contentCache: CachedMetadata | null, filePrefix: string | null): Record<string, string> {
-        const snippets: Record<string, string> = {};
+		if (!contentCache?.headings) {
+			return snippets; // No headings found, return empty snippets
+		}
 
-        if (!contentCache?.headings) {
-            return snippets; // No headings found, return empty snippets
-        }
+		const headings = contentCache.headings;
+		const level = headings[0].level;
 
-        const headings = contentCache.headings;
-        const level = headings[0].level;
+		// Ensure all headings are at the same level
+		for (let i = 0; i < headings.length; i++) {
+			if (headings[i].level !== level) {
+				new Notice(
+					`Please follow the same heading level throughout the file`
+				);
+				return snippets;
+			}
+		}
 
-        // Ensure all headings are at the same level
-        for (let i = 0; i < headings.length; i++) {
-            if (headings[i].level !== level) {
-                new Notice(`Please follow the same heading level throughout the file`);
-                return snippets;
-            }
-        }
+		// Iterate over headings and capture content
+		for (let i = 0; i < headings.length; i++) {
+			const currentHeading = headings[i];
+			let sectionContent = "";
 
-        // Iterate over headings and capture content
-        for (let i = 0; i < headings.length; i++) {
-            const currentHeading = headings[i];
-            let sectionContent = '';
+			if (i + 1 === headings.length) {
+				sectionContent = content.slice(
+					currentHeading.position.end.offset + 1
+				);
+			} else {
+				const nextHeading = headings[i + 1];
+				sectionContent = content.slice(
+					currentHeading.position.end.offset + 1,
+					nextHeading.position.start.offset - 1
+				);
+			}
 
-            if (i + 1 === headings.length) {
-                sectionContent = content.slice(currentHeading.position.end.offset + 1);
-            } else {
-                const nextHeading = headings[i + 1];
-                sectionContent = content.slice(
-                    currentHeading.position.end.offset + 1,
-                    nextHeading.position.start.offset - 1
-                );
-            }
+			// Remove code block formatting
+			sectionContent =
+				this.stripCodeBlockFormatting(sectionContent).trim();
 
-            // Remove code block formatting
-            sectionContent = this.stripCodeBlockFormatting(sectionContent).trim();
+			// Prefix with file name if needed
+			const snippetKey = filePrefix && filePrefix !== ''
+				? `${filePrefix}: ${currentHeading.heading}`
+				: currentHeading.heading;
 
-            // Prefix with file name if needed
-            const snippetKey = filePrefix ? `${filePrefix}: ${currentHeading.heading}` : currentHeading.heading;
+			// Store the section content with the heading as the key
+			snippets[snippetKey] = sectionContent;
+		}
 
-            // Store the section content with the heading as the key
-            snippets[snippetKey] = sectionContent;
-        }
+		return snippets;
+	}
 
-        return snippets;
-    }
+	stripCodeBlockFormatting(content: string): string {
+		return content.replace(/```[\s\S]*?```/g, (match) => {
+			// Remove the starting and ending backticks, and any language identifier
+			return match.replace(/```(\w+)?\n?/, "").replace(/\n?```$/, "");
+		});
+	}
 
-    stripCodeBlockFormatting(content: string): string {
-        return content.replace(/```[\s\S]*?```/g, (match) => {
-            // Remove the starting and ending backticks, and any language identifier
-            return match.replace(/```(\w+)?\n?/, '').replace(/\n?```$/, '');
-        });
-    }
+	// Save the snippets as a JSON file in Alfred's snippet format
+	async saveSnippetsAsAlfredJson() {
+		if (!this.settings.alfredSupport) {
+			return;
+		}
 
+		let idCounter = 1; // Initialize a counter for sequential UIDs
+		const alfredSnippets = Object.keys(this.snippets).map((key) => {
+			return {
+				uid: idCounter++, // Unique ID for each snippet
+				title: key, // Snippet title
+				subtitle: this.snippets[key], // Snippet content
+				arg: this.snippets[key], // Snippet content
+				key: key, // Set the key as the trigger keyword
+			};
+		});
 
-    // Save the snippets as a JSON file in Alfred's snippet format
-    async saveSnippetsAsAlfredJson() {
-        if(!this.settings.alfredSupport) {
-            return;
-        }
+		const jsonContent = JSON.stringify({ items: alfredSnippets }, null, 2); // Format the JSON
+		const jsonFilePath = `${this.manifest.dir}/alfred-snippets.json`; // Path to store the JSON file in the plugin's directory
 
-        let idCounter = 1; // Initialize a counter for sequential UIDs
-        const alfredSnippets = Object.keys(this.snippets).map((key) => {
-            return {
-                    "uid": idCounter++, // Unique ID for each snippet
-                    "title": key, // Snippet title
-                    "subtitle": this.snippets[key], // Snippet content
-                    "arg": this.snippets[key], // Snippet content
-                    "key": key // Set the key as the trigger keyword
-            };
-        });
+		try {
+			await this.app.vault.adapter.write(jsonFilePath, jsonContent); // Save the JSON file
+			// new Notice(`Snippets saved as Alfred JSON in: ${jsonFilePath}`);
+		} catch (error) {
+			console.error("Error saving snippets as Alfred JSON:", error);
+			new Notice("Failed to save snippets as Alfred JSON");
+		}
+	}
 
-        const jsonContent = JSON.stringify({ items: alfredSnippets }, null, 2); // Format the JSON
-        const jsonFilePath = `${this.manifest.dir}/alfred-snippets.json`; // Path to store the JSON file in the plugin's directory
+	async loadSettings() {
+		const data = await this.loadData();
 
-        try {
-            await this.app.vault.adapter.write(jsonFilePath, jsonContent); // Save the JSON file
-            // new Notice(`Snippets saved as Alfred JSON in: ${jsonFilePath}`);
-        } catch (error) {
-            console.error('Error saving snippets as Alfred JSON:', error);
-            new Notice('Failed to save snippets as Alfred JSON');
-        }
-    }
+		// Migrate old setting (snippetFilePath) to the new one (snippetPath) if it exists
+		if (data?.snippetFilePath && !data.snippetPath) {
+			data.snippetPath = data.snippetFilePath; // Copy old setting to the new key
+			delete data.snippetFilePath; // Optionally remove the old key if no longer needed
+		}
 
-    async loadSettings() {
-        const data = await this.loadData();
+		// Merge default settings with loaded/migrated settings
+		this.settings = Object.assign({}, DEFAULT_SETTINGS, data);
 
-        // Migrate old setting (snippetFilePath) to the new one (snippetPath) if it exists
-        if (data?.snippetFilePath && !data.snippetPath) {
-            data.snippetPath = data.snippetFilePath; // Copy old setting to the new key
-            delete data.snippetFilePath; // Optionally remove the old key if no longer needed
-        }
+		// Save settings after migration to ensure future consistency
+		await this.saveSettings();
+	}
 
-        // Merge default settings with loaded/migrated settings
-        this.settings = Object.assign({}, DEFAULT_SETTINGS, data);
+	async saveSettings() {
+		await this.saveData(this.settings);
+	}
 
-        // Save settings after migration to ensure future consistency
-        await this.saveSettings();
-    }
+	function getRelativePath(file: TFile, rootPath: string): string {
+		let relativePath = file.path.slice(rootPath.length);
+		if (relativePath.startsWith('/')) {
+			relativePath = relativePath.slice(1);
+		}
+		return relativePath.replace(/\.md$/, '');
+	}
 
-    async saveSettings() {
-        await this.saveData(this.settings);
-    }
+	function getAllMarkdownFiles(folder: TFolder): TFile[] {
+		let markdownFiles: TFile[] = [];
+
+		folder.children.forEach((child) => {
+			if (child instanceof TFile && child.extension === "md") {
+				markdownFiles.push(child);
+			} else if (child instanceof TFolder) {
+				markdownFiles = markdownFiles.concat(getAllMarkdownFiles(child));
+			}
+		});
+
+		return markdownFiles;
+	}
+
 }

--- a/src/SnippetManagerPlugin.ts
+++ b/src/SnippetManagerPlugin.ts
@@ -80,7 +80,7 @@ export default class SnippetManagerPlugin extends Plugin {
 		}
 
 		if (fileOrFolder instanceof TFolder) {
-			const markdownFiles = getAllMarkdownFiles(fileOrFolder);
+			const markdownFiles = this.getAllMarkdownFiles(fileOrFolder);
 
 			const addFilePrefix = markdownFiles.length > 1;
 
@@ -118,14 +118,12 @@ export default class SnippetManagerPlugin extends Plugin {
 			const contentCache = this.app.metadataCache.getFileCache(file);
 
 			// Merge snippets from this file into the global snippets
-			const filePrefix = addFilePrefix ? getRelativePath(file, this.settings.snippetPath) : null;
+			const filePrefix = addFilePrefix
+				? this.getRelativePath(file, this.settings.snippetPath)
+				: null;
 			Object.assign(
 				this.snippets,
-				this.getSnippets(
-					content,
-					contentCache,
-					filePrefix
-				)
+				this.getSnippets(content, contentCache, filePrefix)
 			);
 
 			this.lastModifiedTimes[filePath] = modifiedTime;
@@ -180,9 +178,10 @@ export default class SnippetManagerPlugin extends Plugin {
 				this.stripCodeBlockFormatting(sectionContent).trim();
 
 			// Prefix with file name if needed
-			const snippetKey = filePrefix && filePrefix !== ''
-				? `${filePrefix}: ${currentHeading.heading}`
-				: currentHeading.heading;
+			const snippetKey =
+				filePrefix && filePrefix !== ""
+					? `${filePrefix}: ${currentHeading.heading}`
+					: currentHeading.heading;
 
 			// Store the section content with the heading as the key
 			snippets[snippetKey] = sectionContent;
@@ -247,26 +246,27 @@ export default class SnippetManagerPlugin extends Plugin {
 		await this.saveData(this.settings);
 	}
 
-	function getRelativePath(file: TFile, rootPath: string): string {
+	getRelativePath(file: TFile, rootPath: string): string {
 		let relativePath = file.path.slice(rootPath.length);
-		if (relativePath.startsWith('/')) {
+		if (relativePath.startsWith("/")) {
 			relativePath = relativePath.slice(1);
 		}
-		return relativePath.replace(/\.md$/, '');
+		return relativePath.replace(/\.md$/, "");
 	}
 
-	function getAllMarkdownFiles(folder: TFolder): TFile[] {
+	getAllMarkdownFiles(folder: TFolder): TFile[] {
 		let markdownFiles: TFile[] = [];
 
 		folder.children.forEach((child) => {
 			if (child instanceof TFile && child.extension === "md") {
 				markdownFiles.push(child);
 			} else if (child instanceof TFolder) {
-				markdownFiles = markdownFiles.concat(getAllMarkdownFiles(child));
+				markdownFiles = markdownFiles.concat(
+					this.getAllMarkdownFiles(child)
+				);
 			}
 		});
 
 		return markdownFiles;
 	}
-
 }


### PR DESCRIPTION
Per issue https://github.com/ramandv/obsidian-snippets-manager/issues/4, and satisfying my own need for this excellent plugin, this PR adds support for snippets defined in markdown files in nested folders in addition to the root snippets folder.

- Existing functionality is unchanged: If there is a list of Markdown files in the snippets folder, it still works as before
- Ditto for a single snippets file
- But if there are nested markdown files, these will now appear (with the key simply including the slash delimiter as a string)

I've tested all the existing scenarios, including Alfred, and it seems good to go.

Super helpful plugin, thanks, and I hope this increases its usage!